### PR TITLE
Revert "updated schema for sources from jaffle_shop to new_jaffle_shop"

### DIFF
--- a/models/staging/_sources.yml
+++ b/models/staging/_sources.yml
@@ -1,7 +1,7 @@
 sources:
   - name: jaffle_shop
     database: raw
-    schema: new_jaffle_shop
+    schema: jaffle_shop
     description: E-commerce data
     tables:
       - name: customers


### PR DESCRIPTION
Reverts dbt-labs/dbt-Explorer-on-demand-course-platform#29

This is as learners are using only jaffle_shop and not new_jaffle_shop